### PR TITLE
fixed referenced assets path

### DIFF
--- a/Resources/views/Default/base-v2.html.twig
+++ b/Resources/views/Default/base-v2.html.twig
@@ -35,7 +35,7 @@ Powered by: Flint Labs H5BP v1 Frontend Bundle
 {% block stylesheets %}
 {% endblock %}
 
-    <script src="{{ asset('bundles/flintlabsH5BP/v2/js/libs/modernizr-2.0.6.min.js') }}"></script>
+    <script src="{{ asset('bundles/flintlabsh5bp/v2/js/libs/modernizr-2.0.6.min.js') }}"></script>
 </head>
 
 <body>
@@ -43,10 +43,10 @@ Powered by: Flint Labs H5BP v1 Frontend Bundle
 {% block body %}{% endblock %}
 
     <script src="//ajax.googleapis.com/ajax/libs/jquery/1.6.2/jquery.min.js"></script>
-    <script>window.jQuery || document.write('<script src="{{ asset('bundles/flintlabsH5BP/v2/js/libs/jquery-1.6.2.min.js') }}"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="{{ asset('bundles/flintlabsh5bp/v2/js/libs/jquery-1.6.2.min.js') }}"><\/script>')</script>
 
 {% block javascripts %}
-    <script defer src="{{ asset('bundles/flintlabsH5BP/v2/js/plugins.js') }}"></script>
+    <script defer src="{{ asset('bundles/flintlabsh5bp/v2/js/plugins.js') }}"></script>
 
     <!--[if lt IE 7 ]>
         <script src="//ajax.googleapis.com/ajax/libs/chrome-frame/1.0.3/CFInstall.min.js"></script>


### PR DESCRIPTION
the reference to bundles/flintlabsh5bp contained uppercase letters which stopped it working on case-sensitive filesystems, like linux
