### PR TITLE
added Content-Type meta tag to fix charset issue with Symfony2 Tests

### DIFF
--- a/Resources/views/Default/base-v2.html.twig
+++ b/Resources/views/Default/base-v2.html.twig
@@ -17,6 +17,7 @@ Powered by: Flint Labs H5BP v1 Frontend Bundle
 {% endblock %}
 -->
     <meta charset="utf-8">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
 
     <title>{% block title %}{% endblock %}</title>


### PR DESCRIPTION
PHP DomDocument needs Content-Type meta tag to correctly identify character encoding, this is a fix for that issue.
See: http://www.php.net/manual/en/domdocument.loadhtml.php#78243
